### PR TITLE
icwt implementation

### DIFF
--- a/src/mod/Transforms.jl
+++ b/src/mod/Transforms.jl
@@ -137,11 +137,11 @@ end # for
 # cwt(Y::AbstractVector, ::ContinuousWavelet)
 
 """
-wave = cwt(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WT.WaveletBoundary}
+wave = cwt(Y::AbstractArray{T}, c::CFW{W}; J1::Int64=-1, dt::S=NaN, s0::V=NaN) where {T<:Real, S<:Real, V<:Real, W<:WT.WaveletBoundary}
 
 return the continuous wavelet transform wave, which is (nscales)×(signalLength), of type c of Y. J1 is the total number of scales; default (when J1=NaN, or is negative) is just under the maximum possible number, i.e. the log base 2 of the length of the signal, times the number of wavelets per octave. If you have sampling information, you will need to scale wave by δt^(1/2).
 """
-function cwt(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WT.WaveletBoundary}
+function cwt(Y::AbstractArray{T}, c::CFW{W}; J1::Int64=-1, dt::S=NaN, s0::V=NaN) where {T<:Real, S<:Real, V<:Real, W<:WT.WaveletBoundary}
     n1 = length(Y);
     # don't alter scaling with sampling information if it doesn't exists
     fλ = (4*π) / (c.σ[1] + sqrt(2 + c.σ[1]^2))
@@ -156,6 +156,7 @@ function cwt(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real,
     if J1<0
         J1 = Int(round(log2(n1 * dt / s0) * c.scalingFactor))
     end
+
     # scales from Mallat 1999
     sj = s0 * 2.0.^(collect(0:J1)./c.scalingFactor)
     # Fourier equivalent frequencies
@@ -222,7 +223,6 @@ function caveats(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:R
     return period, scale, coi
 end
 cwt(Y::AbstractArray{T}, w::WT.ContinuousWaveletClass; J1::Int64=-1, dt::S=NaN, s0::V=NaN) where {T<:Real, S<:Real, V<:Real} = cwt(Y,CFW(w),J1=J1,dt=dt,s0=s0)
-cwt(Y::AbstractArray{T}, w::WT.ContinuousWaveletClass, scalingFactor::U=8; J1::Int64=-1, dt::S=NaN, s0::V=NaN) where {T<:Real, S<:Real, U<:Real, V<:Real} = cwt(Y,CFW(w,scalingFactor), J1=J1,dt=dt,s0=s0)
 caveats(Y::AbstractArray{T}, w::WT.ContinuousWaveletClass; J1::S=NaN) where {T<: Real, S<: Real} = caveats(Y,CFW(w),J1=J1)
 cwt(Y::AbstractArray{T}) where T<:Real = cwt(Y,WT.Morlet())
 caveats(Y::AbstractArray{T}) where T<:Real = caveats(Y,WT.Morlet())
@@ -243,7 +243,6 @@ cwt(Y::AbstractArray{T}, w::WT.ContinuousWaveletClass, sj::AbstractArray; dt::S=
 function psi(c::CFW{W}, t::Int64) where W<:WT.WaveletBoundary
     return π^(-0.25) * exp.(im*c.σ[1]*t - t^2 / 2)
 end
-
 
 
 # WPT (wavelet packet transform)

--- a/src/mod/Transforms.jl
+++ b/src/mod/Transforms.jl
@@ -183,6 +183,7 @@ period,scale, coi = caveats(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<
 returns the period, the scales, and the cone of influence for the given wavelet transform. If you have sampling information, you will need to scale the vector scale appropriately by 1/δt, and the actual transform by δt^(1/2).
 """
 function caveats(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WT.WaveletBoundary}
+    n1 = length(Y);
     # J1 is the total number of elements
     if isnan(J1) || (J1<0)
         J1=floor(Int,(log2(n1))*c.scalingFactor);
@@ -197,7 +198,7 @@ function caveats(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:R
     end
     ω = [0:floor(Int, n/2); -floor(Int,n/2)+1:-1]*2π
     period = c.fourierFactor*2 .^((0:J1)/c.scalingFactor)
-    scale = [1E-5; 1:((n1+1)/2-1); flipdim((1:(n1/2-1)),1); 1E-5]
+    scale = [1E-5; 1:((n1+1)/2-1); reverse((1:(n1/2-1)),dims=1); 1E-5]
     coi = c.coi*scale  # COI [Sec.3g]
     return period, scale, coi
 end

--- a/src/mod/Transforms.jl
+++ b/src/mod/Transforms.jl
@@ -192,7 +192,7 @@ function cwt(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real,
     coi = (n1 / 2 .- abs.(collect(0:n1-1) .- (n1 - 1) ./ 2))
     coi = (fλ * dt / sqrt(2)).*coi
 
-    return reverse(wave', dims=1), sj, freqs, coi
+    return reverse(reverse(wave', dims=1), dims=2), sj, freqs, coi
 end
 """
 period,scale, coi = caveats(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WT.WaveletBoundary}

--- a/src/mod/Transforms.jl
+++ b/src/mod/Transforms.jl
@@ -192,7 +192,7 @@ function cwt(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real,
     coi = (n1 / 2 .- abs.(collect(0:n1-1) .- (n1 - 1) ./ 2))
     coi = (fλ * dt / sqrt(2)).*coi
 
-    return wave, sj, freqs, coi
+    return reverse(wave', dims=1), sj, freqs, coi
 end
 """
 period,scale, coi = caveats(Y::AbstractArray{T}, c::CFW{W}; J1::S=NaN) where {T<:Real, S<:Real, W<:WT.WaveletBoundary}


### PR DESCRIPTION
I added an icwt function based on Torrence and Compo, 1998 (and its implementation in pycwt). I also updated the cwt function to use Julia 1.0, e.g. changed flipdim() to reverse(), and changed how scales and frequencies are defined. The original purpose of these changes was to have consistent wavelet transform results between Python and Julia, so the implementation closely resembles that in pycwt.